### PR TITLE
Changing the hello world from DOM to vanilla

### DIFF
--- a/hello-world.js
+++ b/hello-world.js
@@ -1,1 +1,1 @@
-document.writeln("Hello World!")
+console.log("Hello World!")


### PR DESCRIPTION
The current implementation of the JavaScript hello world is using an
extension to the runtime (DOM), not vanilla JavaScript.

The console implementation is more accepted across all implementations
and this fix will allow the example to run via `node hello-world.js`.